### PR TITLE
support for storage_path in projects cmd

### DIFF
--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -823,8 +823,14 @@ class Commands(object):
         except:
             return
 
-        projects_path = os.path.join(expanduser("~"), '.viper', 'projects')
+        cfg = Config()
+        if cfg.paths.storage_path:
+            base_path = cfg.paths.storage_path
+        else:
+            base_path = os.path.join(expanduser("~"), '.viper')
 
+        projects_path = os.path.join(base_path, 'projects')
+        
         if not os.path.exists(projects_path):
             self.log('info', "The projects directory does not exist yet")
             return


### PR DESCRIPTION
if the storage_path was defined in the cfg file, it will no be considered when using projects.

This should fix it.